### PR TITLE
Removed dependency on weave servers for testing.

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -166,8 +166,8 @@ func Check(p *CheckParams) (*CheckResponse, error) {
 		}
 	}
 
-	u.Scheme = "https"
-	u.Host = "checkpoint-api.weave.works"
+	u.Scheme = os.Getenv("CHECKPOINT_SCHEME")
+	u.Host = os.Getenv("CHECKPOINT_HOST")
 	u.Path = fmt.Sprintf("/v1/check/%s", p.Product)
 	u.RawQuery = v.Encode()
 


### PR DESCRIPTION
- Start httptest server before the tests and teardown the server after the test completes.
- The checkpoint host and scheme are not configurable via environment variables, so they are not hardcoded to be weave.checkpoint